### PR TITLE
NXBT-2332 generate studio registries when packages depend on nuxeo 9.10+

### DIFF
--- a/generators/package/templates/src/main/assemble/assembly.xml
+++ b/generators/package/templates/src/main/assemble/assembly.xml
@@ -144,7 +144,7 @@
       </filterset>
     </copy>
 
-<% if (v.isAfterOrEquals('9.10-SNAPSHOT')) { -%>
+<% if (v.isAfterOrEquals('9.10')) { -%>
     <!-- Studio Registries Extraction -->
     <nx:studioExtraction todir="${outdir}/marketplace">
       <fileset dir="${outdir}/marketplace/install/bundles"/>

--- a/generators/package/templates/src/main/assemble/assembly.xml
+++ b/generators/package/templates/src/main/assemble/assembly.xml
@@ -144,6 +144,13 @@
       </filterset>
     </copy>
 
+<% if (v.isAfterOrEquals('9.10-SNAPSHOT')) { -%>
+    <!-- Studio Registries Extraction -->
+    <nx:studioExtraction todir="${outdir}/marketplace">
+      <fileset dir="${outdir}/marketplace/install/bundles"/>
+    </nx:studioExtraction>
+<% } -%>
+
     <zip destfile="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" basedir="${outdir}/marketplace"/>
     <artifact:attach file="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" type="zip"/>
   </target>


### PR DESCRIPTION
That's as far as I can go, will need your help to integrate this change in Nuxeo CLI and make a release please.